### PR TITLE
(WIP) fix: only consume & send heads once ready

### DIFF
--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -209,6 +209,7 @@ class OrbitDB {
 
     // ID of the store is the address as a string
     const addr = address.toString()
+    store.ready = new Promise(resolve => { store.events.on('ready', resolve) })
     this.stores[addr] = store
 
     // Subscribe to pubsub to get updates from peers,
@@ -228,6 +229,7 @@ class OrbitDB {
   // Callback for receiving a message from the network
   async _onMessage (address, heads) {
     const store = this.stores[address]
+    await store.ready
     try {
       logger.debug(`Received ${heads.length} heads for '${address}':\n`, JSON.stringify(heads.map(e => e.hash), null, 2))
       if (store && heads && heads.length > 0) {
@@ -247,6 +249,8 @@ class OrbitDB {
     const onChannelCreated = channel => { this._directConnections[channel._receiverID] = channel }
 
     const onMessage = (address, heads) => this._onMessage(address, heads)
+
+    await getStore(address).ready
 
     await exchangeHeads(
       this._ipfs,


### PR DESCRIPTION
More comprehensive follow up to https://github.com/orbitdb/orbit-db/pull/683

This solves issue from #683 and another issue described in the 3box linked issue in #683. But described more clearly below (hopefully) 

Before fix:
onPeerConnected and onMessage where called before the db was finished loading. 

1) For onPeerConnect this called exchangeHeads, part of this was getting the heads from this._opload.heads, but before the db is 'ready' with would return [ ] even when there was heads that would be eventually available.

2) For onMessage, db.sync would be called before it was loaded, so there was situations where a past head could be written to _remoteHeads in cache (and result in heads lost). For example client1 has Nth head in cache at  _remoteHeads, client2  knows up to N-1th head, client2 is already open, then client1 opens, client1 connects and gets N-1th head from client2, this is consumed through onMessage and then db.sync (which calls onLoadCompleted when processed), which there N-1th is used to create db._oplog.heads. When this happens before 'ready', the log built from existing cache (Nth head) is not necessarily ready yet (db.load), so when sync writes _remoteHeads it writes N-1th head, when it should wait and write Nth head.

This implementation breaks tests, compared to the last. Looks like many of the fails are from tests not using db.load(). 

Whats the expected use of db.load? should it always be called, or is that not assumed. In that case, instead of blocking consume/send of message until ready, I would change implementation to  just add listener to ready event that redundantly consumes/sends if it was not ready on original call, but is ready after. (similar to #683, but also for writing to _remoteHeads, although seems less than ideal in that case)
