### PR TITLE
Relay events from db scope to orbitdb scope

### DIFF
--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -339,7 +339,6 @@ class OrbitDB {
     const dir = db && db.options.directory ? db.options.directory : this.directory
     await this._requestCache(address, dir, db._cache)
     this.stores[address] = db
-    this.events.emit('load', address)
   }
 
   async _determineAddress (name, type, options = {}) {

--- a/test/create-open.test.js
+++ b/test/create-open.test.js
@@ -407,7 +407,8 @@ Object.keys(testAPIs).forEach(API => {
           let dbAddres
           const handleEvent = (addr => dbAddres = addr)
           orbitdb.events.once('load',  handleEvent)
-          db = await orbitdb.open('load_event_test', { create: true, type: 'feed'})
+          db = await orbitdb.open('load_event_test', { create: true, type: 'feed', relayEvents:['load'] })
+          await db.add('test')
           await db.load()
           assert.equal(dbAddres, db.address.toString())
       })

--- a/test/create-open.test.js
+++ b/test/create-open.test.js
@@ -394,6 +394,32 @@ Object.keys(testAPIs).forEach(API => {
         await db.drop()
         await db2.drop()
       })
+
+      it('emits open event when opening database', async () => {
+          let dbAddres
+          const handleEvent = (addr => dbAddres = addr)
+          orbitdb.events.once('open',  handleEvent)
+          db = await orbitdb.open('open_event_test', { create: true, type: 'feed' })
+          assert.equal(dbAddres, db.address.toString())
+      })
+
+      it('emits load event when opening database', async () => {
+          let dbAddres
+          const handleEvent = (addr => dbAddres = addr)
+          orbitdb.events.once('load',  handleEvent)
+          db = await orbitdb.open('load_event_test', { create: true, type: 'feed'})
+          await db.load()
+          assert.equal(dbAddres, db.address.toString())
+      })
+
+      it('relays ready event when opening database', async () => {
+          let dbAddres
+          const handleEvent = (addr => dbAddres = addr)
+          orbitdb.events.once('ready',  handleEvent)
+          db = await orbitdb.open('ready_event_test', { create: true, type: 'feed', relayEvents:['ready'] })
+          await db.load()
+          assert.equal(dbAddres, db.address.toString())
+      })
     })
 
     describe("Close", function () {


### PR DESCRIPTION
Adds a `realyEvents:[]` param to :
 - ` OrbitDB.createInstance()`
 - `orbit.db.create()`
 - `orbitdb.open()`

This enables listeners to be created at the parent orbitdb instance level, allowing events to be trapped for db creation before the creation process even begins.
This is especially needed for the http api where opening a remote db can take extended periods of time, and http clients will enforce a relatively shorter time-out period when there is no activity.
Some basic tests are included for the `open`, `load` and `ready` events
More tests can be added later if needed.
 
Example:
```
orbitdb.events.on('ready', ((addr) => console.log(`DB ${addr} is ready`))
db = await orbitdb.open('ready_event_test', { create: true, type: 'feed', relayEvents:['ready'] })
```
