### PR TITLE
Added a test for hasCapability in the "grant" section.

### DIFF
--- a/test/access-controllers/orbit-db-access-controller.test.js
+++ b/test/access-controllers/orbit-db-access-controller.test.js
@@ -154,6 +154,12 @@ Object.keys(testAPIs).forEach(API => {
           delete: new Set(['ABCD'])
         })
       })
+      
+      it("granted capability can be checked with hasCapability", async () => {
+          assert.ok(accessController.hasCapability("read", "ABCD"))
+          assert.ok(accessController.hasCapability("delete", "ABCD"))
+          assert.ok(!accessController.hasCapability("read", "invalidKey"))
+      })
 
       it('emit \'updated\' event when a capability was added', async () => {
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
Added a test for `hasCapability`created in [PR](https://github.com/orbitdb/orbit-db-access-controllers/pull/67). 

This test will only work, if that PR is merged first and the proper
version of orbit-db-access-controller is published.