### PR TITLE
OrbitDBAddress.isValid and parseAddress accept CIDs.

### DIFF
--- a/src/orbit-db-address.js
+++ b/src/orbit-db-address.js
@@ -2,8 +2,6 @@
 const path = require('path')
 const { CID } = require('multiformats/cid')
 
-const notEmpty = e => e !== '' && e !== ' '
-
 class OrbitDBAddress {
   constructor (root, path) {
     this.root = root
@@ -17,34 +15,21 @@ class OrbitDBAddress {
   static isValid (address) {
     address = address.toString().replace(/\\/g, '/')
 
-    const containsProtocolPrefix = (e, i) => !((i === 0 || i === 1) && address.toString().indexOf('/orbit') === 0 && e === 'orbitdb')
+    const parts = address.split('/')
 
-    const parts = address.toString()
-      .split('/')
-      .filter(containsProtocolPrefix)
-      .filter(notEmpty)
+    if (parts.length < 3) return false
 
-    let accessControllerHash
+    const hasProtocol = address.startsWith('/orbitdb/')
 
-    const validateHash = (hash) => {
-      const prefixes = ['zd', 'Qm', 'ba', 'k5']
-      for (const p of prefixes) {
-        if (hash.indexOf(p) > -1) {
-          return true
-        }
-      }
-      return false
-    }
+    let validHash
 
     try {
-      accessControllerHash = validateHash(parts[0])
-        ? CID.parse(parts[0]).toString()
-        : null
+      validHash = !!CID.parse(parts[2])
     } catch (e) {
-      return false
+      validHash = false
     }
 
-    return accessControllerHash !== null
+    return hasProtocol && validHash
   }
 
   static parse (address) {

--- a/test/orbit-db-address.test.js
+++ b/test/orbit-db-address.test.js
@@ -95,13 +95,6 @@ Object.keys(testAPIs).forEach(API => {
         assert.equal(result, true)
       })
 
-      it('handle missing orbitdb prefix', () => {
-        const address = 'zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13/first-database'
-        const result = OrbitDB.isValidAddress(address)
-
-        assert.equal(result, true)
-      })
-
       it('handle missing db address name', () => {
         const address = '/orbitdb/zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13'
         const result = OrbitDB.isValidAddress(address)

--- a/test/orbit-db-address.test.js
+++ b/test/orbit-db-address.test.js
@@ -38,14 +38,14 @@ Object.keys(testAPIs).forEach(API => {
     describe('Parse Address', () => {
       it('throws an error if address malformatted.', () => {
         let addresses = ["", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13/first-database", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13", "/orbitdb//first-database"]
-        address.forEach(address => {
+        addresses.forEach(address => {
           let err
           try {
             const result = OrbitDB.parseAddress(address)
           } catch (e) {
             err = e.toString()
           }
-          assert.equal(err, 'Error: Not a valid OrbitDB address: ')
+          assert.equal(err, 'Error: Not a valid OrbitDB address: ' + address)
         })
       })
 
@@ -82,7 +82,7 @@ Object.keys(testAPIs).forEach(API => {
       it('returns false for malformatted addresses', () => {
         let addresses = ["", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13/first-database", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13", "/orbitdb//first-database"]
 
-        address.forEach(address => {
+        addresses.forEach(address => {
           const result = OrbitDB.isValidAddress(address)
           assert.equal(result, false)
         })

--- a/test/orbit-db-address.test.js
+++ b/test/orbit-db-address.test.js
@@ -24,22 +24,20 @@ Object.keys(testAPIs).forEach(API => {
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api
-      orbitdb = await OrbitDB.createInstance(ipfs, {
-        directory: dbPath
-      })
+      orbitdb = await OrbitDB.createInstance(ipfs, { directory: dbPath })
     })
 
     after(async () => {
-      if (orbitdb)
+      if(orbitdb)
         await orbitdb.stop()
 
-      if (ipfsd)
+      if(ipfsd)
         await stopIpfs(ipfsd)
     })
 
     describe('Parse Address', () => {
       it('throws an error if address malformatted.', () => {
-        let addresses = ["", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw1/first-database", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw1", "/orbitdb//first-database"]
+        let addresses = ["", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13/first-database", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13", "/orbitdb//first-database"]
         address.forEach(address => {
           let err
           try {
@@ -52,7 +50,7 @@ Object.keys(testAPIs).forEach(API => {
       })
 
       it('parse address successfully', () => {
-        const address = '/orbitdb/zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw1/first-database'
+        const address = '/orbitdb/zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13/first-database'
         const result = OrbitDB.parseAddress(address)
 
         const isInstanceOf = result instanceof OrbitDBAddress
@@ -82,7 +80,7 @@ Object.keys(testAPIs).forEach(API => {
 
     describe('isValid Address', () => {
       it('returns false for malformatted addresses', () => {
-        let addresses = ["", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw1/first-database", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw1", "/orbitdb//first-database"]
+        let addresses = ["", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13/first-database", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13", "/orbitdb//first-database"]
 
         address.forEach(address => {
           const result = OrbitDB.isValidAddress(address)
@@ -128,3 +126,4 @@ Object.keys(testAPIs).forEach(API => {
 
   })
 })
+

--- a/test/orbit-db-address.test.js
+++ b/test/orbit-db-address.test.js
@@ -24,11 +24,13 @@ Object.keys(testAPIs).forEach(API => {
       rmrf.sync(dbPath)
       ipfsd = await startIpfs(API, config.daemon1)
       ipfs = ipfsd.api
-      orbitdb = await OrbitDB.createInstance(ipfs, { directory: dbPath })
+      orbitdb = await OrbitDB.createInstance(ipfs, {
+        directory: dbPath
+      })
     })
 
     after(async () => {
-      if(orbitdb)
+      if (orbitdb)
         await orbitdb.stop()
 
       if (ipfsd)
@@ -36,18 +38,21 @@ Object.keys(testAPIs).forEach(API => {
     })
 
     describe('Parse Address', () => {
-      it('throws an error if address is empty', () => {
-        let err
-        try {
-          const result = OrbitDB.parseAddress('')
-        } catch (e) {
-          err = e.toString()
-        }
-        assert.equal(err, 'Error: Not a valid OrbitDB address: ')
+      it('throws an error if address malformatted.', () => {
+        let addresses = ["", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw1/first-database", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw1", "/orbitdb//first-database"]
+        address.forEach(address => {
+          let err
+          try {
+            const result = OrbitDB.parseAddress(address)
+          } catch (e) {
+            err = e.toString()
+          }
+          assert.equal(err, 'Error: Not a valid OrbitDB address: ')
+        })
       })
 
       it('parse address successfully', () => {
-        const address = '/orbitdb/zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw13/first-database'
+        const address = '/orbitdb/zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw1/first-database'
         const result = OrbitDB.parseAddress(address)
 
         const isInstanceOf = result instanceof OrbitDBAddress
@@ -76,9 +81,13 @@ Object.keys(testAPIs).forEach(API => {
     })
 
     describe('isValid Address', () => {
-      it('returns false for empty string', () => {
-        const result = OrbitDB.isValidAddress('')
-        assert.equal(result, false)
+      it('returns false for malformatted addresses', () => {
+        let addresses = ["", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw1/first-database", "zdpuAuK3BHpS7NvMBivynypqciYCuy2UW77XYBPUYRnLjnw1", "/orbitdb//first-database"]
+
+        address.forEach(address => {
+          const result = OrbitDB.isValidAddress(address)
+          assert.equal(result, false)
+        })
       })
 
       it('validate address successfully', () => {


### PR DESCRIPTION
Refer to this issue for more details: https://github.com/orbitdb/orbit-db/issues/924

`OrbitDB.isValid` returns true and `parseAddress` returns a proper `OrbitDBAddress` object when given a CID as input without name or protocol.

For Example:
```js
> OrbitDB.isValidAddress("QmTeAppWEwssc4d4soLj1yMeDEZUHtbCzvaGVWKzBYFa25")
true
```

This PR will try to add further tests for both of these functions on edge cases and change the behavior of the two functions in order to not accept any Address string that does not conform to this pattern (`<name>` part is optional): `/orbitdb/<manifest-cid>/<name>`