### PR TITLE
Make 'keystore' not undefined

### DIFF
--- a/src/OrbitDB.js
+++ b/src/OrbitDB.js
@@ -111,6 +111,10 @@ class OrbitDB {
       options.keystore = new Keystore(keyStorage)
     }
 
+    if (options.identity && !options.identity.provider.keystore) {
+      options.identity.provider = { keystore: options.keystore };
+    }
+
     if (!options.identity) {
       options.identity = await Identities.createIdentity({
         id: id,


### PR DESCRIPTION
This PR fixes `TypeError: Cannot read properties of undefined (reading 'keystore')` when `options.identity` is defined and `options.identity.provider.keystore` is not.