### PR TITLE
Update stale references to examples:node and get Dockerfile updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Check the code in [examples/browser/browser.html](https://github.com/orbitdb/orb
 ### Node.js example
 
 ```
-npm run examples:node
+npm run examples:eventlog
 ```
 
 <img src="https://raw.githubusercontent.com/orbitdb/orbit-db/master/images/orbit-db-demo3.gif" width="66%">

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,3 +14,4 @@ USER node
 
 RUN npm install babel-cli webpack ipfs \
  && npm install
+RUN npm install orbit-db

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:lts
 
 ENV NPM_CONFIG_PREFIX=/home/node/.npm-global
 
@@ -12,5 +12,5 @@ COPY conf/ ./conf
 RUN chown -R node:node package.json examples src conf
 USER node
 
-RUN npm install babel-cli webpack \
+RUN npm install babel-cli webpack ipfs \
  && npm install

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ docker build -t orbit-db -f docker/Dockerfile .
 After building local image, run node.js-examples inside container:
 
 ```bash
-docker run -ti --rm orbit-db npm run examples:node
+docker run -ti --rm orbit-db npm run examples:eventlog
 ```
 
 ## Why would you want to run OrbitDB in container?


### PR DESCRIPTION
As a newcomer to the project, I wanted to try and get up and running quickly with the Docker environment, but the Dockerfile references a very old version of node that doesn't work with OrbitDB. This has been fixed, as well as the README.md that had a reference to the removed/stale examples:node script (which I replaced with examples:eventlog)

On my Ubuntu WSL Docker system the Dockerfile build and runs the examples correctly.