### PR TITLE
Use only bitswap in tests

### DIFF
--- a/test/utils/create-helia.js
+++ b/test/utils/create-helia.js
@@ -1,4 +1,5 @@
 import { createHelia } from 'helia'
+import { bitswap } from 'helia/block-brokers'
 import { createLibp2p } from 'libp2p'
 import { DefaultLibp2pOptions, DefaultLibp2pBrowserOptions } from '../../src/index.js'
 
@@ -9,5 +10,10 @@ export default async () => {
 
   const libp2p = await createLibp2p({ ...options })
 
-  return createHelia({ libp2p })
+  const heliaOptions = {
+    libp2p,
+    blockBrokers: [bitswap()]
+  }
+
+  return createHelia({ ...heliaOptions })
 }


### PR DESCRIPTION
This PR removes the default `[trustlessGateway](https://github.com/ipfs/helia/blob/299bb0942bbfae492db938c4ccad4e835bab2dbd/packages/helia/src/helia.ts#L49)` used in helia and changes the configuration to use `bitswap` instead.

Doing so removes various calls to the gateway urls in tests.