### PR TITLE
Improve Oplog performance

### DIFF
--- a/src/oplog/entry.js
+++ b/src/oplog/entry.js
@@ -147,8 +147,13 @@ const isEqual = (a, b) => {
  * @private
  */
 const decode = async (bytes) => {
-  const { value } = await Block.decode({ bytes, codec, hasher })
-  return encode(value)
+  const { cid, value } = await Block.decode({ bytes, codec, hasher })
+  const hash = cid.toString(hashStringEncoding)
+  return {
+    ...value,
+    hash,
+    bytes
+  }
 }
 
 /**

--- a/src/oplog/log.js
+++ b/src/oplog/log.js
@@ -326,7 +326,7 @@ const Log = async (identity, { logId, logHeads, access, entryStorage, headsStora
    * @memberof module:Log~Log
    * @instance
    */
-  const traverse = async function * (rootEntries, shouldStopFn, useRefs = true) {
+  const traverse = async function * (rootEntries, shouldStopFn) {
     // By default, we don't stop traversal and traverse
     // until the end of the log
     const defaultStopFn = () => false
@@ -350,7 +350,7 @@ const Log = async (identity, { logId, logHeads, access, entryStorage, headsStora
       // Get the next entry from the stack
       entry = stack.pop()
       if (entry) {
-        const { hash, next, refs } = entry
+        const { hash, next } = entry
         // If we have an entry that we haven't traversed yet, process it
         if (!traversed[hash]) {
           // Yield the current entry
@@ -365,7 +365,7 @@ const Log = async (identity, { logId, logHeads, access, entryStorage, headsStora
           fetched[hash] = true
           // Add the next and refs hashes to the list of hashes to fetch next,
           // filter out traversed and fetched hashes
-          toFetch = [...toFetch, ...next, ...(useRefs ? refs : [])].filter(notIndexed)
+          toFetch = [...toFetch, ...next].filter(notIndexed)
           // Function to fetch an entry and making sure it's not a duplicate (check the hash indices)
           const fetchEntries = (hash) => {
             if (!traversed[hash] && !fetched[hash]) {
@@ -379,7 +379,7 @@ const Log = async (identity, { logId, logHeads, access, entryStorage, headsStora
           // Add the next and refs fields from the fetched entries to the next round
           toFetch = nexts
             .filter(e => e !== null && e !== undefined)
-            .reduce((res, acc) => Array.from(new Set([...res, ...acc.next, ...(useRefs ? acc.refs : [])])), [])
+            .reduce((res, acc) => Array.from(new Set([...res, ...acc.next])), [])
             .filter(notIndexed)
           // Add the fetched entries to the stack to be processed
           stack = [...nexts, ...stack]
@@ -543,7 +543,7 @@ const Log = async (identity, { logId, logHeads, access, entryStorage, headsStora
     const shouldStopTraversal = async (entry) => {
       return refs.length >= amount && amount !== -1
     }
-    for await (const { hash } of traverse(heads, shouldStopTraversal, false)) {
+    for await (const { hash } of traverse(heads, shouldStopTraversal)) {
       refs.push(hash)
     }
     refs = refs.slice(heads.length + 1, amount)


### PR DESCRIPTION
This PR improves the overall query performance for all databases.

The improvements come from two changes to the Oplog.

1) Remove an unnecessary entry encoding step

In Entry's `decode()` function we had it so that we encoded the entry once the serialized block was decoded. This was unnecessary and by removing this step we gain a significant write and read performance improvement. From:
```
Starting benchmark...
Insert 1000 documents
Inserting 1000 documents took 1642 ms, 609 ops/s, 1.642 ms/op
Query 1000 documents
Querying 1000 documents took 72 ms, 13888 ops/s, 0.072 ms/op
```
To:
```
Starting benchmark...
Insert 1000 documents
Inserting 1000 documents took 1284 ms, 778 ops/s, 1.284 ms/op
Query 1000 documents
Querying 1000 documents took 52 ms, 19230 ops/s, 0.052 ms/op
```

2) Remove `useRefs` in oplog's traverse() function

We don't need to use the `refs` anymore in `traverse` as we changed the entry loading logic a while back. Removing it improves the query performance time from:
```
Querying 1000 documents took 52 ms, 19230 ops/s, 0.052 ms/op
```
To:
```
Querying 1000 documents took 27 ms, 37037 ops/s, 0.027 ms/op
```

Altogether with these two changes, the performance improvement is:

Before:
```
Inserting 1000 documents took 1642 ms, 609 ops/s, 1.642 ms/op
Querying 1000 documents took 72 ms, 13888 ops/s, 0.072 ms/op
```

After:
```
Inserting 1000 documents took 1284 ms, 778 ops/s, 1.284 ms/op
Querying 1000 documents took 27 ms, 37037 ops/s, 0.027 ms/op
```

This PR is on top of #1176.