### PR TITLE
chore: Iterate gossipsub. Changes to gossipsub options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ const Libp2pOptions = {
   services: {
     pubsub: gossipsub({
       // neccessary to run a single peer
-      allowPublishToZeroPeers: true
+      allowPublishToZeroTopicPeers: true
     }),
     identify: identify()
   }

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -54,7 +54,7 @@ A simple Node.js example might look something like:
   streamMuxers: [yamux()],
   services: {
     identify: identify(),
-    pubsub: gossipsub({ allowPublishToZeroPeers: true })
+    pubsub: gossipsub({ allowPublishToZeroTopicPeers: true })
   }
 }
 ```
@@ -83,7 +83,7 @@ export const Libp2pOptions = {
   streamMuxers: [yamux()],
   services: {
     identify: identify(),
-    pubsub: gossipsub({ allowPublishToZeroPeers: true })
+    pubsub: gossipsub({ allowPublishToZeroTopicPeers: true })
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "uint8arrays": "^5.0.0"
       },
       "devDependencies": {
-        "@chainsafe/libp2p-gossipsub": "^12.0.0",
+        "@chainsafe/libp2p-gossipsub": "^13.0.0",
         "@chainsafe/libp2p-yamux": "^6.0.1",
         "@helia/block-brokers": "^1.0.0",
         "@libp2p/circuit-relay-v2": "^1.0.10",
@@ -2580,9 +2580,9 @@
       "integrity": "sha512-ndGqEMG1W5WkGagaqOZHpPU172AGdxr+LD15sv3WIUvT5oCFUrG1Y0CW/v2Egwj4JXEvSibaIIIqImsm98y1nA=="
     },
     "node_modules/@chainsafe/libp2p-gossipsub": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-12.0.0.tgz",
-      "integrity": "sha512-ZuVIvzZjUaZXSPG6Ni9veVBLkZ4OkVp3zc3E8Y5EG/iIUSNVbHLFxweb3HuA12e3lIXLLurvy4vDyGWp4FpKow==",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-13.0.0.tgz",
+      "integrity": "sha512-2q+v429uZjMl6N3d+j9QCMj8YO0aiYvLSN1t0aTdpMXQHCHLJaaT9PtNn845B1Li7/uZjYESmikgVt8r7keH0w==",
       "dev": true,
       "dependencies": {
         "@libp2p/crypto": "^4.0.1",
@@ -2605,19 +2605,19 @@
       }
     },
     "node_modules/@chainsafe/libp2p-gossipsub/node_modules/@libp2p/crypto": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.2.tgz",
-      "integrity": "sha512-zdFnnP2dA3X/xqRyJus+5rgCrp7JHFh+C8hA+DckXqp+ayiRMyLnKKPXmSzTKJSsIABMW2pcUFU+yCeDSgiSQQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.6.tgz",
+      "integrity": "sha512-AJ4i3DHOTlY961O26M3k1IjmU4rUd5WgeK4t9IRzFfLIbD6uwA+cevJMG2qr0UHJfbYdGKKQ2Po1wqZONoIA9Q==",
       "dev": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.3",
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
+        "@libp2p/interface": "^1.2.0",
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0",
         "asn1js": "^3.0.5",
-        "multiformats": "^13.0.1",
+        "multiformats": "^13.1.0",
         "protons-runtime": "^5.4.0",
         "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.1"
+        "uint8arrays": "^5.0.3"
       }
     },
     "node_modules/@chainsafe/libp2p-gossipsub/node_modules/multiformats": {
@@ -3666,8 +3666,7 @@
     "node_modules/@leichtgewicht/ip-codec": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
-      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
-      "dev": true
+      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
     },
     "node_modules/@libp2p/autonat": {
       "version": "1.0.12",
@@ -3785,27 +3784,27 @@
       }
     },
     "node_modules/@libp2p/interface": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.1.3.tgz",
-      "integrity": "sha512-id22Ve5acg6CM0jjL8s9cyEaBYWn7z1R+1gy75RpHi0qgW15ifozwi0oFSTGLVA5XzRnNzioDLj+ZP6QwvhIVQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-1.2.0.tgz",
+      "integrity": "sha512-ImnGNl3El/AukgaojACT8i9SNW1FOsrThcQU/qA3w5tEBR5p84Uwgzl/nxa4X5vGinItUJ9jLEJmtkQJENoiGQ==",
       "dependencies": {
-        "@multiformats/multiaddr": "^12.1.14",
+        "@multiformats/multiaddr": "^12.2.1",
         "it-pushable": "^3.2.3",
         "it-stream-types": "^2.0.1",
-        "multiformats": "^13.0.1",
+        "multiformats": "^13.1.0",
         "progress-events": "^1.0.0",
         "uint8arraylist": "^2.4.8"
       }
     },
     "node_modules/@libp2p/interface-internal": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-1.0.8.tgz",
-      "integrity": "sha512-NkUBnqzAAWDcg9n4uUtEpbtHg0gZjLhdBTwqJWkWuTujaCEz0xk5FfXBXgWqGEMIZAN73VX8/hLQCeigk3gUlg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface-internal/-/interface-internal-1.1.0.tgz",
+      "integrity": "sha512-B6Cu3Mhp5kY2Z1cU0soCR4ZtjZtE4FuWE0qdJNauOpcQe9HOjPF8SanFmeEIZ0FKSOo0onQdQi2YdNUTtOVyvQ==",
       "dev": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.3",
-        "@libp2p/peer-collections": "^5.1.6",
-        "@multiformats/multiaddr": "^12.1.14",
+        "@libp2p/interface": "^1.2.0",
+        "@libp2p/peer-collections": "^5.1.10",
+        "@multiformats/multiaddr": "^12.2.1",
         "uint8arraylist": "^2.4.8"
       }
     },
@@ -3914,16 +3913,16 @@
       "dev": true
     },
     "node_modules/@libp2p/logger": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.6.tgz",
-      "integrity": "sha512-ofTE3kDivBJnUSoX68nOeg1EuAnIE8oUjUnQnuKrxH+nh0JtjTcvwwIzjmm4nApwb4xj2dgPSDvU38Mjmu3TvA==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/logger/-/logger-4.0.10.tgz",
+      "integrity": "sha512-JiRfJHO/D9Jlh2rJ6STnONoeQevBAdAZaGUxrtvBf4RFfucldSFEMOtdkFO8xFGuiA90Q2kj4BE2douG6fB3Lw==",
       "dev": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.3",
-        "@multiformats/multiaddr": "^12.1.14",
+        "@libp2p/interface": "^1.2.0",
+        "@multiformats/multiaddr": "^12.2.1",
         "debug": "^4.3.4",
-        "interface-datastore": "^8.2.10",
-        "multiformats": "^13.0.1"
+        "interface-datastore": "^8.2.11",
+        "multiformats": "^13.1.0"
       }
     },
     "node_modules/@libp2p/logger/node_modules/multiformats": {
@@ -3982,24 +3981,24 @@
       }
     },
     "node_modules/@libp2p/peer-collections": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-5.1.6.tgz",
-      "integrity": "sha512-n2Oav1GehdEToeALvSytuYw2wiwzMvbOUxyAFUfF6oqmZgNe9P8cOkyr0w2P0p0hXjdcIeIfDYeTvY4MeHZnjw==",
+      "version": "5.1.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-collections/-/peer-collections-5.1.10.tgz",
+      "integrity": "sha512-Edr4FBzCgE7FRgc0wfYfcmihQ4GDHwkQP7xMG4oOVoIxHEzuk9Nb2opK9cLbK+nU4oAROgFLzJEJuiG7BGV2hg==",
       "dev": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.3",
-        "@libp2p/peer-id": "^4.0.6"
+        "@libp2p/interface": "^1.2.0",
+        "@libp2p/peer-id": "^4.0.10"
       }
     },
     "node_modules/@libp2p/peer-id": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-4.0.6.tgz",
-      "integrity": "sha512-hAj2bdN+s/cCkiaLthuL412DqLeYZ83yRmbjZfHHJ8d3sV/M7NAxu2v8Zx+3KurFF8ICMoD7bb34IXHo7FH3kw==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@libp2p/peer-id/-/peer-id-4.0.10.tgz",
+      "integrity": "sha512-cR5dQ5fPcxP4LLSXDgo+TSOhtElZSwRXVSSgT/GM/Vvbua5M91NzsksYfd/lg8XwTCSvTER0qmE6ZIR05vjQrA==",
       "dev": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.3",
-        "multiformats": "^13.0.1",
-        "uint8arrays": "^5.0.1"
+        "@libp2p/interface": "^1.2.0",
+        "multiformats": "^13.1.0",
+        "uint8arrays": "^5.0.3"
       }
     },
     "node_modules/@libp2p/peer-id-factory": {
@@ -4147,40 +4146,40 @@
       "dev": true
     },
     "node_modules/@libp2p/pubsub": {
-      "version": "9.0.10",
-      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-9.0.10.tgz",
-      "integrity": "sha512-oYvDM14NNXyFLnrVVQISrWZE1DZSOfHd7tQW/M+/Pl2iICsrMuj/ViZ8BFjGE2RkJflHXKGV5bdEqQNQMIoJ/g==",
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-9.0.15.tgz",
+      "integrity": "sha512-zhHKoCxI/pNsTpuTmBzPNcPOpzK50EuP2Wxgf3im3KaQix7XQ5WH/sHYGdWc4e0dkrrZYmvvvtoOBYbjVLeqYw==",
       "dev": true,
       "dependencies": {
-        "@libp2p/crypto": "^4.0.2",
-        "@libp2p/interface": "^1.1.3",
-        "@libp2p/interface-internal": "^1.0.8",
-        "@libp2p/peer-collections": "^5.1.6",
-        "@libp2p/peer-id": "^4.0.6",
-        "@libp2p/utils": "^5.2.5",
+        "@libp2p/crypto": "^4.0.6",
+        "@libp2p/interface": "^1.2.0",
+        "@libp2p/interface-internal": "^1.1.0",
+        "@libp2p/peer-collections": "^5.1.10",
+        "@libp2p/peer-id": "^4.0.10",
+        "@libp2p/utils": "^5.3.1",
         "it-length-prefixed": "^9.0.4",
         "it-pipe": "^3.0.1",
         "it-pushable": "^3.2.3",
-        "multiformats": "^13.0.1",
+        "multiformats": "^13.1.0",
         "p-queue": "^8.0.1",
         "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.1"
+        "uint8arrays": "^5.0.3"
       }
     },
     "node_modules/@libp2p/pubsub/node_modules/@libp2p/crypto": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.2.tgz",
-      "integrity": "sha512-zdFnnP2dA3X/xqRyJus+5rgCrp7JHFh+C8hA+DckXqp+ayiRMyLnKKPXmSzTKJSsIABMW2pcUFU+yCeDSgiSQQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-4.0.6.tgz",
+      "integrity": "sha512-AJ4i3DHOTlY961O26M3k1IjmU4rUd5WgeK4t9IRzFfLIbD6uwA+cevJMG2qr0UHJfbYdGKKQ2Po1wqZONoIA9Q==",
       "dev": true,
       "dependencies": {
-        "@libp2p/interface": "^1.1.3",
-        "@noble/curves": "^1.3.0",
-        "@noble/hashes": "^1.3.3",
+        "@libp2p/interface": "^1.2.0",
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0",
         "asn1js": "^3.0.5",
-        "multiformats": "^13.0.1",
+        "multiformats": "^13.1.0",
         "protons-runtime": "^5.4.0",
         "uint8arraylist": "^2.4.8",
-        "uint8arrays": "^5.0.1"
+        "uint8arrays": "^5.0.3"
       }
     },
     "node_modules/@libp2p/pubsub/node_modules/multiformats": {
@@ -4218,24 +4217,24 @@
       }
     },
     "node_modules/@libp2p/utils": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-5.2.5.tgz",
-      "integrity": "sha512-oMUrBvEFGD/74I3W3AhpV3pLx8CeEhxCpoJ9a0BTetoJ+TbU5DxxcWJGvhoq3RfQiUvZtg0IwJWNaiJ6lB2sdA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-5.3.1.tgz",
+      "integrity": "sha512-FdGzRU50PJLYSEOmVXqqtq27yjUVXkU4QNRZzMVuXF9L/sKgSC2oXwj0Satc9fHx5tG3MCX1ZOSAmYEIl2fu+w==",
       "dev": true,
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.2",
-        "@libp2p/interface": "^1.1.3",
-        "@libp2p/logger": "^4.0.6",
-        "@multiformats/multiaddr": "^12.1.14",
-        "@multiformats/multiaddr-matcher": "^1.1.2",
+        "@libp2p/interface": "^1.2.0",
+        "@libp2p/logger": "^4.0.10",
+        "@multiformats/multiaddr": "^12.2.1",
+        "@multiformats/multiaddr-matcher": "^1.2.0",
         "delay": "^6.0.0",
         "get-iterator": "^2.0.1",
         "is-loopback-addr": "^2.0.2",
         "it-pushable": "^3.2.3",
         "it-stream-types": "^2.0.1",
         "netmask": "^2.0.2",
-        "p-defer": "^4.0.0",
-        "race-event": "^1.1.0",
+        "p-defer": "^4.0.1",
+        "race-event": "^1.2.0",
         "race-signal": "^1.0.2",
         "uint8arraylist": "^2.4.8"
       }
@@ -4325,6 +4324,20 @@
       "integrity": "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==",
       "dev": true
     },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.6.tgz",
+      "integrity": "sha512-nt/5UqjMPtyvkG9BQYdJ4GfLK3nMqGpFZOzf4hAmIa0sJh2LlS9YKXZ4FgwBDsaHvzZqR/rUFIywIc7pkHNNuw==",
+      "dependencies": {
+        "@types/dns-packet": "^5.6.5",
+        "buffer": "^6.0.3",
+        "dns-packet": "^5.6.1",
+        "hashlru": "^2.3.0",
+        "p-queue": "^8.0.1",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^5.0.2"
+      }
+    },
     "node_modules/@multiformats/mafmt": {
       "version": "12.1.6",
       "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-12.1.6.tgz",
@@ -4335,23 +4348,23 @@
       }
     },
     "node_modules/@multiformats/multiaddr": {
-      "version": "12.1.14",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.1.14.tgz",
-      "integrity": "sha512-1C0Mo73chzu7pTzTquuKs5vUtw70jhqg1i6pUNznGb0WV6RFa6vyB+D697Os5+cLx+DiItrAY6VzMtlGQsMzYg==",
+      "version": "12.2.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.2.1.tgz",
+      "integrity": "sha512-UwjoArBbv64FlaetV4DDwh+PUMfzXUBltxQwdh+uTYnGFzVa8ZfJsn1vt1RJlJ6+Xtrm3RMekF/B+K338i2L5Q==",
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
         "@chainsafe/netmask": "^2.0.0",
         "@libp2p/interface": "^1.0.0",
-        "dns-over-http-resolver": "^3.0.2",
+        "@multiformats/dns": "^1.0.3",
         "multiformats": "^13.0.0",
         "uint8-varint": "^2.0.1",
         "uint8arrays": "^5.0.0"
       }
     },
     "node_modules/@multiformats/multiaddr-matcher": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.1.2.tgz",
-      "integrity": "sha512-O7hO+TYsweMjNCqTYKYn8iki2GXA46mxmgqnsOb2Wpr6ca4dRGnPldWTai2WwTeZpQyRJ/7GE+N9zPTfP0xE+Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr-matcher/-/multiaddr-matcher-1.2.0.tgz",
+      "integrity": "sha512-LH6yR7h3HSNKcxuvvi2UpLuowuVkYC6H9Y3jqmKuTai8XtKnXtW6NcDZFD/ooTBY+H4yX/scoJpjOalHrk5qdQ==",
       "dev": true,
       "dependencies": {
         "@chainsafe/is-ip": "^2.0.1",
@@ -4389,20 +4402,20 @@
       }
     },
     "node_modules/@noble/curves": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
-      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
+      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
       "dependencies": {
-        "@noble/hashes": "1.3.3"
+        "@noble/hashes": "1.4.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
-      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "engines": {
         "node": ">= 16"
       },
@@ -6110,7 +6123,6 @@
       "version": "5.6.5",
       "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.5.tgz",
       "integrity": "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==",
-      "dev": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -6215,7 +6227,6 @@
       "version": "20.10.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.4.tgz",
       "integrity": "sha512-D08YG6rr8X90YB56tSIuBaddy/UXAA9RKJoFvrsnogAum/0pmjkgi4+2nx96A330FmioegBWmEYQ+syqCFaveg==",
-      "dev": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -8088,6 +8099,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -8317,20 +8329,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/dns-over-http-resolver": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/dns-over-http-resolver/-/dns-over-http-resolver-3.0.2.tgz",
-      "integrity": "sha512-5batkHOjCkuAfrFa+IPmt3jyeZqLtSMfAo1HQp3hfwtzgUwHooecTFplnYC093u5oRNL4CQHCXh3OfER7+vWrA==",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "receptacle": "^1.3.2"
-      }
-    },
     "node_modules/dns-packet": {
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
       "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
-      "dev": true,
       "dependencies": {
         "@leichtgewicht/ip-codec": "^2.0.1"
       },
@@ -10121,8 +10123,7 @@
     "node_modules/hashlru": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
-      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
-      "dev": true
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A=="
     },
     "node_modules/hasown": {
       "version": "2.0.0",
@@ -10438,13 +10439,13 @@
       "dev": true
     },
     "node_modules/interface-datastore": {
-      "version": "8.2.10",
-      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.10.tgz",
-      "integrity": "sha512-D8RuxMdjOPB+j6WMDJ+I2aXTDzUT6DIVjgzo1E+ODL7w8WrSFl9FXD2SYmgj6vVzdb7Kb5qmAI9pEnDZJz7ifg==",
+      "version": "8.2.11",
+      "resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-8.2.11.tgz",
+      "integrity": "sha512-9E0iXehfp/j0UbZ2mvlYB4K9pP7uQBCppfuy8WHs1EHF6wLQrM9+zwyX+8Qt6HnH4GKZRyXX/CNXm6oD4+QYgA==",
       "dev": true,
       "dependencies": {
         "interface-store": "^5.0.0",
-        "uint8arrays": "^5.0.0"
+        "uint8arrays": "^5.0.2"
       }
     },
     "node_modules/interface-store": {
@@ -13316,7 +13317,8 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
     },
     "node_modules/multibase": {
       "version": "4.0.6",
@@ -13957,9 +13959,9 @@
       }
     },
     "node_modules/p-defer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.0.tgz",
-      "integrity": "sha512-Vb3QRvQ0Y5XnF40ZUWW7JfLogicVh/EnA5gBIvKDJoYpeI82+1E3AlB9yOcKFS0AhHrWVnAQO39fbR0G99IVEQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-4.0.1.tgz",
+      "integrity": "sha512-Mr5KC5efvAK5VUptYEIopP1bakB85k2IWXaRC0rsh1uwn1L6M0LVml8OIQ4Gudg4oyZakf7FmeRLkMMtZW1i5A==",
       "engines": {
         "node": ">=12"
       },
@@ -14791,9 +14793,9 @@
       ]
     },
     "node_modules/race-event": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/race-event/-/race-event-1.1.0.tgz",
-      "integrity": "sha512-8BTiN6IAbov8mqkVEc3LiYbtUzanLfzFhwPF7kZV74ztYeQXdFPIgMCd/sy8xie6ZMtf2JPeMBedx78/RRNO3g==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/race-event/-/race-event-1.2.0.tgz",
+      "integrity": "sha512-7EvAjTu9uuKa03Jky8yfSy6/SnnMTh6nouNmdeWv9b0dT8eDZC5ylx30cOR9YO9otQorVjjkIuSHQ5Ml/bKwMw==",
       "dev": true
     },
     "node_modules/race-signal": {
@@ -15083,14 +15085,6 @@
       },
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/receptacle": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/receptacle/-/receptacle-1.3.2.tgz",
-      "integrity": "sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==",
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/rechoir": {
@@ -16959,9 +16953,9 @@
       }
     },
     "node_modules/uint8arrays": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.1.tgz",
-      "integrity": "sha512-ND5RpJAnPgHmZT7hWD/2T4BwRp04j8NLKvMKC/7bhiEwEjUMkQ4kvBKiH6hOqbljd6qJ2xS8reL3vl1e33grOQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.0.3.tgz",
+      "integrity": "sha512-6LBuKji28kHjgPJMkQ6GDaBb1lRwIhyOYq6pDGwYMoDPfImE9SkuYENVmR0yu9yGgs2clHUSY9fKDukR+AXfqQ==",
       "dependencies": {
         "multiformats": "^13.0.0"
       }
@@ -16995,8 +16989,7 @@
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "uint8arrays": "^5.0.0"
   },
   "devDependencies": {
-    "@chainsafe/libp2p-gossipsub": "^12.0.0",
+    "@chainsafe/libp2p-gossipsub": "^13.0.0",
     "@chainsafe/libp2p-yamux": "^6.0.1",
     "@helia/block-brokers": "^1.0.0",
     "@libp2p/circuit-relay-v2": "^1.0.10",

--- a/test/utils/create-helia.js
+++ b/test/utils/create-helia.js
@@ -34,7 +34,7 @@ const Libp2pOptions = {
   },
   services: {
     identify: identify(),
-    pubsub: gossipsub({ allowPublishToZeroPeers: true })
+    pubsub: gossipsub({ allowPublishToZeroTopicPeers: true })
   }
 }
 
@@ -61,7 +61,7 @@ const Libp2pBrowserOptions = {
   },
   services: {
     identify: identify(),
-    pubsub: gossipsub({ allowPublishToZeroPeers: true })
+    pubsub: gossipsub({ allowPublishToZeroTopicPeers: true })
   }
 }
 


### PR DESCRIPTION
Update gossipsub options in line with [release notes](https://github.com/ChainSafe/js-libp2p-gossipsub/releases).

The OrbitDB examples, tests and documentation will refer to the latest version of GossipSub. OrbitDB instances implementing older versions of GossipSub will not work with these examples.