### PR TITLE
Docs: Fix links & docstring formatting

### DIFF
--- a/docs/DATABASES.md
+++ b/docs/DATABASES.md
@@ -208,7 +208,7 @@ for await (const record of db2.iterator()) {
 }
 ```
 
-To learn more, check out [OrbitDB's sychronization protocol](https://orbitdb.org/api/module-Sync.html) and the [OrbitDB replication documentation](./REPLICATION.md).
+To learn more, check out [OrbitDB's sychronization protocol](https://api.orbitdb.org/module-Sync.html) and the [OrbitDB replication documentation](./REPLICATION.md).
 
 ## Custom databases
 

--- a/docs/REPLICATION.md
+++ b/docs/REPLICATION.md
@@ -80,4 +80,4 @@ await orbitdb2.stop()
 await ipfs2.stop()
 ```
 
-Refer to the API for more information about [OrbitDB's synchronization protocol](https://orbitdb.org/api/module-Sync.html).
+Refer to the API for more information about [OrbitDB's synchronization protocol](https://api.orbitdb.org/module-Sync.html).

--- a/src/sync.js
+++ b/src/sync.js
@@ -19,7 +19,9 @@ const DefaultTimeout = 30000 // 30 seconds
  * Upon subscribing to the topic, peers already connected to the topic receive
  * the subscription message and "dial" the subscribing peer using a libp2p
  * custom protocol. Once connected to the subscribing peer on a direct
- * peer-to-peer connection, the dialing peer and the subscribing peer exchange * the heads of the Log each peer currently has. Once completed, the peers have * the same "local state".
+ * peer-to-peer connection, the dialing peer and the subscribing peer exchange
+ * the heads of the Log each peer currently has. Once completed, the peers have
+ * the same "local state".
  *
  * Once the initial sync has completed, peers notify one another of updates to
  * the log, ie. updates to the database, using the initially opened pubsub


### PR DESCRIPTION
- fixes links to https://api.orbitdb.org/module-Sync.html
- fixes formatting of sync module docstring