### PR TITLE
Consistent package naming for standalone and replicating db guide

### DIFF
--- a/docs/DATABASES.md
+++ b/docs/DATABASES.md
@@ -264,7 +264,7 @@ CustomDB.type = type
 export default CustomDB
 ```
 
-[Documents](../src/db/documents.js), [Events](../src/db/events.js) and [KeyValue](../src/db/keyvalue.js) provide good examples of how a database is implemented in OrbitDB and how to add the logic for returning records from the database (the state of the database).
+[Documents](../src/databases/documents.js), [Events](../src/databases/events.js) and [KeyValue](../src/databases/keyvalue.js) provide good examples of how a database is implemented in OrbitDB and how to add the logic for returning records from the database (the state of the database).
 
 To use a custom database, add it to the list of supported database types:
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -195,7 +195,7 @@ To create an OrbitDB database peer, create a new project called `orbitdb-peer`:
 mkdir orbitdb-peer
 cd orbitdb-peer
 npm init
-npm i helia orbitdb/core blockstore-level @chainsafe/libp2p-gossipsub
+npm i helia @orbitdb/core blockstore-level @chainsafe/libp2p-gossipsub
 ```
 
 Create a new file called index.js and paste in the following code:


### PR DESCRIPTION
When following the Getting Started guide, this npm scoped install did not work, therefore corrected it in sync with the standalone installation guide
`npm i helia @orbitdb/core blockstore-level @chainsafe/libp2p-gossipsub`