### PR TITLE
fix: Update relay example to use default reservation ttl setting

### DIFF
--- a/test/utils/relay.js
+++ b/test/utils/relay.js
@@ -29,13 +29,7 @@ const server = await createLibp2p({
   streamMuxers: [yamux()],
   services: {
     identify: identify(),
-    relay: circuitRelayServer({
-      reservations: {
-        maxReservations: 5000,
-        reservationTtl: 1000,
-        defaultDataLimit: BigInt(1024 * 1024 * 1024)
-      }
-    })
+    relay: circuitRelayServer()
   }
 })
 

--- a/test/utils/relay.js
+++ b/test/utils/relay.js
@@ -29,7 +29,12 @@ const server = await createLibp2p({
   streamMuxers: [yamux()],
   services: {
     identify: identify(),
-    relay: circuitRelayServer()
+    relay: circuitRelayServer({
+      reservations: {
+        maxReservations: 5000,
+        defaultDataLimit: BigInt(1024 * 1024 * 1024)
+      }
+    })
   }
 })
 


### PR DESCRIPTION
The current relay example specifies custom `reservationTtl` and other settings for `CircuitRelayServer`. However, recent versions of the library include more generous default settings.

With the current configuration, reservations are dropped too quickly by the relay due to a `ttl` set to 1000ms (1 second), while the default is now 2 hours.

This PR updates the example to use the default `CircuitRelayServer` settings, simplifying the configuration:
```js
relay: circuitRelayServer()
```

### Related Issue
This change is related to an issue I encountered while testing browser to browser replication. You can find more details in the issue reported [here](https://github.com/haydenyoung/orbitdb-browser-example/issues/1).

### Note
If preferred, I can adjust the PR to only change the reservationTtl value and keep the rest of the settings as they are.

### Update:
Reverted the other settings because the browser tests were failing. Changing only the ttl setting resolves the issue without causing any test failures, based on local testing.
```js
relay: circuitRelayServer({
      reservations: {
        maxReservations: 5000,
        defaultDataLimit: BigInt(1024 * 1024 * 1024)
      }
    })
```