### PR TITLE
Use `.name` instead of `.code` for errors

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -196,7 +196,7 @@ const Sync = async ({ ipfs, log, events, onSynced, start, timeout }) => {
         } catch (e) {
           console.error(e)
           peers.delete(peerId)
-          if (e.name === 'ERR_UNSUPPORTED_PROTOCOL') {
+          if (e.name === 'UnsupportedProtocolError') {
             // Skip peer, they don't have this database currently
           } else {
             events.emit('error', e)

--- a/src/sync.js
+++ b/src/sync.js
@@ -196,7 +196,7 @@ const Sync = async ({ ipfs, log, events, onSynced, start, timeout }) => {
         } catch (e) {
           console.error(e)
           peers.delete(peerId)
-          if (e.code === 'ERR_UNSUPPORTED_PROTOCOL') {
+          if (e.name === 'ERR_UNSUPPORTED_PROTOCOL') {
             // Skip peer, they don't have this database currently
           } else {
             events.emit('error', e)

--- a/src/sync.js
+++ b/src/sync.js
@@ -194,7 +194,6 @@ const Sync = async ({ ipfs, log, events, onSynced, start, timeout }) => {
           const stream = await libp2p.dialProtocol(remotePeer, headsSyncAddress, { signal })
           await pipe(sendHeads, stream, receiveHeads(peerId))
         } catch (e) {
-          console.error(e)
           peers.delete(peerId)
           if (e.name === 'UnsupportedProtocolError') {
             // Skip peer, they don't have this database currently


### PR DESCRIPTION
Fix for the change in libp2p here: https://github.com/libp2p/js-libp2p/pull/2655