### PR TITLE
Add listener to events.on("error")

### DIFF
--- a/src/sync.js
+++ b/src/sync.js
@@ -133,6 +133,7 @@ const Sync = async ({ ipfs, log, events, onSynced, start, timeout }) => {
    * @instance
    */
   events = events || new EventEmitter()
+  events.on("error", console.log)
 
   timeout = timeout || DefaultTimeout
 


### PR DESCRIPTION
Node.js, by default, throws an error if an EventEmitter emits an "error" event and no other listener is configured. This causes OrbitDB to crash the main thread on Node.js whenever a libp2p error occurs during synchronisation.